### PR TITLE
Add type signature to Haskell function

### DIFF
--- a/HelloWorld.hs
+++ b/HelloWorld.hs
@@ -1,1 +1,3 @@
-main = putStrLn "Hello, World!"
+main :: IO ()
+main = do
+  putStrLn "Hello, World!"


### PR DESCRIPTION
## Description
Though GHC has the ability to implicitly determine the type of a function, as in
```
*Main> :t main
main :: IO ()
```
I've simply added a type signature above the function name.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix or **improving code quality**
- [ ] New language 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
